### PR TITLE
gate two - import from another file

### DIFF
--- a/hub/@gates/two/add.ts
+++ b/hub/@gates/two/add.ts
@@ -1,0 +1,3 @@
+export { ref } from "./ref.ts";
+
+export const add = (a: number, b: number) => a + b;

--- a/hub/@gates/two/json.ts
+++ b/hub/@gates/two/json.ts
@@ -1,0 +1,4 @@
+export const parse = (json: string) => JSON.parse(json);
+export const stringify = (value: unknown) => JSON.stringify(value);
+
+export default { parse, stringify };

--- a/hub/@gates/two/main.ts
+++ b/hub/@gates/two/main.ts
@@ -1,0 +1,42 @@
+import { add, ref as ref1 } from "./add.ts";
+import { minus, subtract } from "./minus.ts";
+
+import * as Math from "./math.ts";
+import JSON from "./json.ts";
+
+import { ref } from "./ref.ts";
+
+export default function serve(request: Request) {
+  return new Response(
+    JSON.stringify({
+      text: `Hello from ${request.url}!`,
+      ref: {
+        value: ref1,
+        "Math/ref === ref": Math.ref === ref,
+        "add/ref === ref": ref1 === ref,
+      },
+      add: {
+        x: 10,
+        y: 20,
+        sum: add(10, 20),
+      },
+      minus: {
+        x: 20,
+        y: 10,
+        difference: minus(20, 10),
+        subtract: subtract(20, 10),
+        "minus === subtract": minus === subtract,
+      },
+    }),
+    {
+      headers: { "content-type": "text/plain" },
+    },
+  );
+}
+
+if (import.meta.main) {
+  Deno.serve(
+    { port: 8080 },
+    serve,
+  );
+}

--- a/hub/@gates/two/math.ts
+++ b/hub/@gates/two/math.ts
@@ -1,0 +1,5 @@
+export * from "./add.ts";
+export * from "./minus.ts";
+
+export * as Add from "./add.ts";
+export * as Minus from "./minus.ts";

--- a/hub/@gates/two/minus.ts
+++ b/hub/@gates/two/minus.ts
@@ -1,0 +1,5 @@
+export function minus(a: number, b: number) {
+  return a - b;
+}
+
+export { minus as subtract };

--- a/hub/@gates/two/ref.ts
+++ b/hub/@gates/two/ref.ts
@@ -1,0 +1,1 @@
+export * as ref from "./test.ts";

--- a/hub/@gates/two/test.ts
+++ b/hub/@gates/two/test.ts
@@ -1,0 +1,11 @@
+export const x = 1;
+
+export const {
+  y,
+  z: { z1, z2: z3 },
+  a: [a1, a2],
+} = {
+  y: "y",
+  z: { z1: "z1", z2: "z2-3" },
+  a: ["a1", "a2"],
+};

--- a/hub/@reframe/core/fs/lib/create.ts
+++ b/hub/@reframe/core/fs/lib/create.ts
@@ -1,15 +1,42 @@
 import type { Base, Ctx, FS } from "../../ctx/ctx.ts";
 import { type Body, createBodyPromise } from "../../body.ts";
 
-export const createFs = <C extends Base>(name: string) => ({
+export const createFs = <C extends Base>(name: string, opts?: {
+  base?: string;
+}) => ({
   read: (read: (ctx: Ctx<C>) => Promise<Body>) => ({
     write: (write: (ctx: Ctx<C>) => Promise<Body>) => {
+      const base = opts?.base ?? "https://localhost";
+      const fsRead = (ctx: Ctx<C>) => createBodyPromise(read(ctx));
+      const fsWrite = (ctx: Ctx<C>) => createBodyPromise(write(ctx));
+
       const fs: FS<C> = {
         name,
-        read: (ctx) => createBodyPromise(read(ctx)),
-        write: (ctx) => createBodyPromise(write(ctx)),
+        read: fsRead,
+        write: fsWrite,
 
         use: (createCtx: (request: Request, fs: FS<C>) => Ctx<C>) => ({
+          name,
+          read: (path: string, headers?: Record<string, string>) =>
+            fsRead(
+              createCtx(
+                new Request(new URL(path, base), {
+                  headers,
+                }),
+                fs,
+              ),
+            ),
+          write: (path: string, body: Body, headers?: Record<string, string>) =>
+            fsWrite(
+              createCtx(
+                new Request(new URL(path, base), {
+                  method: "POST",
+                  body: body.underlying,
+                  headers,
+                }),
+                fs,
+              ),
+            ),
           fetch: async (request: Request) => {
             const ctx = createCtx(request, fs);
             const operation = ctx.operation === "read" ? read : write;

--- a/hub/@reframe/core/runtime.ts
+++ b/hub/@reframe/core/runtime.ts
@@ -1,0 +1,120 @@
+import { Base, Ctx } from "./ctx/ctx.ts";
+
+type Module<T, U> = { default: T } & U;
+
+export type Runtime = {
+  entry: string;
+  enter: (entry: string) => Runtime;
+  moduleCache: Map<string, Promise<Module<unknown, unknown>>>;
+  resolve: (specifier: string, referrer: string) => string;
+  import: <M extends Module<unknown, unknown>>(
+    specifier: string,
+  ) => Promise<M>;
+  importMany: (
+    ...imports: string[]
+  ) => Promise<Record<string, Module<unknown, unknown>>>;
+};
+
+export const createRuntime = <C extends Base>(
+  entry: string,
+  ctx: Ctx<C>,
+): Runtime => {
+  const Runtime = {
+    entry,
+
+    enter: (entry: string) => ({
+      ...Runtime,
+      entry,
+    }),
+
+    moduleCache: new Map<string, Promise<Module<unknown, unknown>>>(),
+
+    resolve: (specifier: string, referrer: string) => {
+      if (specifier.startsWith(".")) {
+        // get the absolute path compared to the current file
+        const segments = referrer.split("/").filter(Boolean);
+        segments.pop(); // remove the file name
+
+        const specifierSegments = specifier.split("/").filter(Boolean);
+
+        for (const segment of specifierSegments) {
+          if (segment === "..") {
+            if (segments.length === 0) {
+              throw new Error(`Invalid specifier: ${specifier}`);
+            }
+
+            segments.pop();
+          } else if (segment !== ".") {
+            segments.push(segment);
+          }
+        }
+
+        return "/" + segments.join("/");
+      }
+
+      return specifier;
+    },
+
+    _import: async (
+      specifier: string,
+    ): Promise<Module<unknown, unknown>> => {
+      const body = await ctx.fs.read(specifier).text();
+
+      try {
+        const url = URL.createObjectURL(
+          new Blob([body], { type: "application/javascript" }),
+        );
+        const module = await import(url);
+        URL.revokeObjectURL(url);
+
+        return module.default(Runtime.enter(specifier));
+      } catch (error) {
+        console.error("import error", specifier, error);
+        throw error;
+      }
+    },
+
+    import: <M extends Module<unknown, unknown>>(
+      specifier: string,
+    ): Promise<M> => {
+      const resolved = Runtime.resolve(specifier, entry);
+
+      if (!Runtime.moduleCache.has(resolved)) {
+        console.log(`%cIMPORT`, "color:salmon;", resolved, "MISS");
+
+        Runtime.moduleCache.set(
+          resolved,
+          Runtime._import(resolved).then((module) => {
+            // TODO: this is a hack - figure wtf this works
+
+            return {
+              ...module,
+              __esModule: true,
+            };
+          }),
+        );
+      }
+
+      console.log("IMPORT", resolved, "HIT");
+
+      return Runtime.moduleCache.get(resolved)! as Promise<M>;
+    },
+
+    importMany: async (...imports: string[]) => {
+      const specifiers = Array.from(new Set(imports));
+
+      const modules = await Promise.all(
+        specifiers.map(
+          async (specifier) =>
+            [specifier, await Runtime.import(specifier)] as const,
+        ),
+      );
+
+      console.log("IMPORT MANY", Runtime.moduleCache);
+
+      return Object.fromEntries(modules);
+    },
+  };
+
+  return Runtime;
+};

--- a/hub/@reframe/core/server.ts
+++ b/hub/@reframe/core/server.ts
@@ -4,6 +4,10 @@ import { moduleServerFs } from "./fs/module-server.ts";
 import { routerFs } from "./fs/router.ts";
 import { unmoduleFs } from "./fs/unmodule.ts";
 
+const f = async () => {
+  throw 42;
+};
+
 export default function serve(
   org: string,
   name: string,
@@ -28,13 +32,18 @@ export default function serve(
 
   Deno.serve(
     { port: 8080 },
-    (request) => {
+    async (request) => {
       // ignore favicon
-      if (request.url.endsWith("/favicon.ico")) {
-        return new Response(null, { status: 404 });
-      }
+      try {
+        if (request.url.endsWith("/favicon.ico")) {
+          return new Response(null, { status: 404 });
+        }
 
-      return server.fetch(request);
+        return await server.fetch(request);
+      } catch (error) {
+        console.error(error);
+        return new Response(error.stack, { status: 500 });
+      }
     },
   );
 }

--- a/hub/@reframe/core/ts/transformers.ts
+++ b/hub/@reframe/core/ts/transformers.ts
@@ -1,7 +1,7 @@
 import { createVisitorTransformer, ts } from "./system.ts";
 
 const normalizeSpecifier = (specifier: string, path: string) => {
-  return "experimental:" + specifier;
+  return specifier;
 };
 
 export const extractExports = (node: ts.Node): string[] => {


### PR DESCRIPTION
In this step, we pass @gates/two, which contains multiple typescript files that
can import from each other. The most significant change here is to introduce
runtime to ctx, which can import modules and evaluate them while maintaining
referential integrity.

### Runtime

Runtime has three primary function, `resolve`, `import` and `importMany`.

- `resolve` takes a path and returns the normalized path where app FS will give
  us its content
- `import` takes a path, fetches the content and evaluates it
- `importMany` takes multiple paths, calls `import` on each of them and returns
  the result as an object. Example:

```ts
const imports = await Runtime.importMany("react", "./math.ts");
const { useState } = imports["react"];
const { add, subtract } = imports["./math.ts"];
```
