### PR TITLE
gate four - cache computations

### DIFF
--- a/hub/@gates/four/add.ts
+++ b/hub/@gates/four/add.ts
@@ -1,0 +1,3 @@
+export { ref } from "./ref.ts";
+
+export const add = (a: number, b: number) => a + b;

--- a/hub/@gates/four/json.ts
+++ b/hub/@gates/four/json.ts
@@ -1,0 +1,4 @@
+export const parse = (json: string) => JSON.parse(json);
+export const stringify = (value: unknown) => JSON.stringify(value);
+
+export default { parse, stringify };

--- a/hub/@gates/four/main.ts
+++ b/hub/@gates/four/main.ts
@@ -1,0 +1,63 @@
+import { add, ref as ref1 } from "./add.ts";
+import { minus, subtract } from "./minus.ts";
+import { Type } from "npm:@sinclair/typebox";
+
+const T = Type.Object({
+  x: Type.Number(),
+  y: Type.Number(),
+  z: Type.Number(),
+});
+
+import * as Math from "./math.ts";
+import JSON from "./json.ts";
+
+import { ref } from "./ref.ts";
+
+export default function serve(request: Request) {
+  return new Response(
+    JSON.stringify({
+      text: `Hello from ${request.url}!`,
+      type: ref.object({
+        type: ref.literal("object"),
+        properties: ref.record(
+          ref.enum([
+            "x",
+            "y",
+            "z",
+          ]),
+          ref.object({
+            type: ref.literal("number").transform((x) => x.toUpperCase()),
+          }),
+        ),
+        required: ref.array(ref.string()),
+      }).parse(T),
+      ref: {
+        value: ref1,
+        "Math/ref === ref": Math.ref === ref,
+        "add/ref === ref": ref1 === ref,
+      },
+      add: {
+        x: 10,
+        y: 20,
+        sum: add(10, 20),
+      },
+      minus: {
+        x: 20,
+        y: 10,
+        difference: minus(20, 10),
+        subtract: subtract(20, 10),
+        "minus === subtract": minus === subtract,
+      },
+    }),
+    {
+      headers: { "content-type": "text/plain" },
+    },
+  );
+}
+
+if (import.meta.main) {
+  Deno.serve(
+    { port: 8080 },
+    serve,
+  );
+}

--- a/hub/@gates/four/math.ts
+++ b/hub/@gates/four/math.ts
@@ -1,0 +1,5 @@
+export * from "./add.ts";
+export * from "./minus.ts";
+
+export * as Add from "./add.ts";
+export * as Minus from "./minus.ts";

--- a/hub/@gates/four/minus.ts
+++ b/hub/@gates/four/minus.ts
@@ -1,0 +1,5 @@
+export function minus(a: number, b: number) {
+  return a - b;
+}
+
+export { minus as subtract };

--- a/hub/@gates/four/ref.ts
+++ b/hub/@gates/four/ref.ts
@@ -1,0 +1,1 @@
+export * as ref from "./test.ts";

--- a/hub/@gates/four/test.ts
+++ b/hub/@gates/four/test.ts
@@ -1,0 +1,13 @@
+export const x = 1;
+
+export const {
+  y,
+  z: { z1, z2: z3 },
+  a: [a1, a2],
+} = {
+  y: "y",
+  z: { z1: "z1", z2: "z2-3" },
+  a: ["a1", "a2"],
+};
+
+export * from "npm:zod";

--- a/hub/@reframe/core/fs/cache.ts
+++ b/hub/@reframe/core/fs/cache.ts
@@ -1,0 +1,26 @@
+import { Base, FS } from "../ctx/ctx.ts";
+import { createFs } from "./lib/create.ts";
+
+export const cacheFs = <C extends Base>(
+  source: FS<C>,
+  cache: FS<C>,
+): FS<C> => {
+  return createFs<C>("cache")
+    .read(async (ctx) => {
+      try {
+        const body = await ctx.forward(cache);
+        ctx.log("HIT", ctx.path);
+        return body;
+      } catch (_error) {
+        ctx.log("MISS", ctx.path);
+        const body = await ctx.forward(source);
+        await ctx.write(cache, body.clone());
+        return body;
+      }
+    })
+    .write(async (ctx) => {
+      const result = await source.write(ctx);
+      await cache.write(ctx);
+      return result;
+    });
+};

--- a/hub/@reframe/core/fs/memory.ts
+++ b/hub/@reframe/core/fs/memory.ts
@@ -1,0 +1,27 @@
+import { Base } from "../ctx/ctx.ts";
+import { getContentType } from "../utils/content-type.ts";
+import { createFs } from "./lib/create.ts";
+
+export const memoryFs = <C extends Base>(contents: Record<string, string>) =>
+  createFs<C>("memory")
+    .read(async (ctx) => {
+      const content = contents[ctx.path];
+
+      if (!content) {
+        throw ctx.notFound();
+      }
+
+      return ctx.text(content, {
+        "x-import-path": ctx.path,
+        "content-type": getContentType(ctx.path),
+      });
+    }).write(
+      async (ctx) => {
+        contents[ctx.path] = await ctx.getBody().text();
+
+        return ctx.text(contents[ctx.path], {
+          "x-import-path": ctx.path,
+          "content-type": getContentType(ctx.path),
+        });
+      },
+    );

--- a/hub/@reframe/core/readme.md
+++ b/hub/@reframe/core/readme.md
@@ -1,43 +1,12 @@
-In this step, we pass @gates/three, which contains imports from npm. For this,
-we create a new fs, npmFs, which resolves npm packages from esm.sh.
+In this step, we pass @gates/four, which is same as @gates/three, but for this
+gate, we need to be able to cache read computations - like transpilation or
+fetching from npm - so that we don't repeat any computation.
 
-Additionally, we update the Runtime.resolve function to be able to resolve
-import paths.
+For this, we create two new fs, cacheFs and memoryFs.
 
-An absolute path can have the following forms:
-
-- /path/to/file
-- loader:/path/to/file
-- loader1:loader2:/path/to/file
-- /~loader/path/to/file (equivalent to loader:/path/to/file)
-- /~loader1/~loader2/path/to/file (equivalent to loader1:loader2:/path/to/file)
-
-Path resolution works on resolving the loader part and the file part separately.
-Some examples:
-
-```js
-resolve("@/x/y/z/a.ts", "./b.ts"); // "@/x/y/z/b.ts"
-
-resolve("@/x/y/z/a.ts", "@reframe/core"); // "@reframe/core"
-
-resolve("@/x/y/z/a.ts", "@/x/y/z/d.ts"); // "@/x/y/z/d.ts"
-
-resolve("transpile:@/x/y/z/a.ts", "./b.ts"); // "transpile:@/x/y/z/b.ts"
-
-resolve("transpile:@/x/y/z/a.ts", "@reframe/core"); // "transpile:@reframe/core"
-
-resolve("transpile:@/x/y/z/a.ts", "@/x/y/z/d.ts"); // "transpile:@/x/y/z/d.ts"
-
-resolve("@/x/y/z/a.ts", "npm:react"); // "npm:react"
-
-resolve("npm:react", "/v135/react/index.js"); // "npm:v135/react/index.js"
-resolve("transpile:npm:react", "/v135/react/index.js"); // "transpile:npm:v135/react/index.js",
-
-resolve("transpile:@/x/y/z/a.ts", "/:./b.ts"); // "@/x/y/z/b.ts",
-
-resolve("transpile:npm:react", "/:transpile:/@reframe/core"); // "transpile:@reframe/core",
-
-resolve("transpile:npm:react", "/:/@reframe/core"); // "@reframe/core",
-
-resolve("transpile:npm:react", "..:/@reframe/core"); // "transpile:@reframe/core",
-```
+- cacheFs(storage, source)
+  - takes two fs, storage and source, and caches each read from source to
+    storage.
+- memoryFs
+  - a simple in-memory fs to use as the storage for cacheFs, although note that
+    any compatible fs can be used as storage since FSes are composable.

--- a/hub/@reframe/core/runtime.ts
+++ b/hub/@reframe/core/runtime.ts
@@ -55,7 +55,7 @@ export const createRuntime = <C extends Base>(
       const resolved = Runtime.resolve(specifier, entry);
 
       if (!Runtime.moduleCache.has(resolved)) {
-        console.log(`%cIMPORT`, resolved, "MISS", "color:salmon;");
+        console.log(`%cIMPORT`, "color:salmon;", resolved, "MISS");
 
         Runtime.moduleCache.set(
           resolved,

--- a/hub/@reframe/core/server.ts
+++ b/hub/@reframe/core/server.ts
@@ -5,6 +5,8 @@ import { moduleServerFs } from "./fs/module-server.ts";
 import { npmFs } from "./fs/npm.ts";
 import { routerFs } from "./fs/router.ts";
 import { unmoduleFs } from "./fs/unmodule.ts";
+import { cacheFs } from "./fs/cache.ts";
+import { memoryFs } from "./fs/memory.ts";
 
 export default function serve(
   org: string,
@@ -14,10 +16,13 @@ export default function serve(
 ) {
   const codeFs = localFs(`/@${org}/${name}`);
 
-  const sourceFs: FS<Base> = routerFs()
-    .mount("/", () => codeFs)
-    .mount("/~@", () => unmoduleFs(sourceFs))
-    .mount("/~npm", () => npmFs());
+  const sourceFs: FS<Base> = cacheFs(
+    routerFs()
+      .mount("/", () => codeFs)
+      .mount("/~@", () => unmoduleFs(sourceFs))
+      .mount("/~npm", () => npmFs()),
+    memoryFs({}),
+  );
 
   const appFs = routerFs()
     .mount("/", () =>


### PR DESCRIPTION
In this step, we pass @gates/four, which is same as @gates/three, but to pass
this gate, we need to be able to cache read computations - like transpilation or
fetching from npm - so that we don't repeat any computation.

For this, we create two new fs, `cacheFs` and `memoryFs`.

- `cacheFs(storage, source)`
  - takes two fs, storage and source, and caches each read from source to
    storage.
- `memoryFs`
  - a simple in-memory fs to use as the storage for cacheFs, although note that
    any compatible fs can be used as storage since FSes are composable.
