### PR TITLE
gate five - compose hooks

### DIFF
--- a/hub/@gates/five/add.ts
+++ b/hub/@gates/five/add.ts
@@ -1,0 +1,3 @@
+export { ref } from "./path/to/ref.ts";
+
+export const add = (a: number, b: number) => a + b;

--- a/hub/@gates/five/json.ts
+++ b/hub/@gates/five/json.ts
@@ -1,0 +1,4 @@
+export const parse = (json: string) => JSON.parse(json);
+export const stringify = (value: unknown) => JSON.stringify(value);
+
+export default { parse, stringify };

--- a/hub/@gates/five/main.ts
+++ b/hub/@gates/five/main.ts
@@ -1,0 +1,76 @@
+import { add, ref as fourRef } from "@gates/four/add.ts";
+import { minus, subtract } from "@gates/three/minus.ts";
+import { resolve } from "@reframe/core/utils/path.ts";
+import { Type } from "npm:@sinclair/typebox";
+
+const T = Type.Object({
+  x: Type.Number(),
+  y: Type.Number(),
+  z: Type.Number(),
+});
+
+import * as Math from "./math.ts";
+import JSON from "./json.ts";
+
+import { ref as relativeRef } from "./path/to/ref.ts";
+import { ref as absoluteRef } from "@/path/to/ref.ts";
+
+export default function serve(request: Request) {
+  return new Response(
+    JSON.stringify({
+      text: `Hello from ${request.url}!`,
+      resolve: {
+        "specifier": "bundle:../../core/utils/path.ts",
+        "importer": "npm:@reframe/core/main.ts",
+        "resolved": resolve(
+          "bundle:../../core/utils/path.ts",
+          "npm:@reframe/core/main.ts",
+        ),
+      },
+      type: relativeRef.object({
+        type: relativeRef.literal("object"),
+        properties: relativeRef.record(
+          relativeRef.enum([
+            "x",
+            "y",
+            "z",
+          ]),
+          relativeRef.object({
+            type: relativeRef.literal("number").transform((x) =>
+              x.toUpperCase()
+            ),
+          }),
+        ),
+        required: relativeRef.array(relativeRef.string()),
+      }).parse(T),
+      ref: {
+        value: relativeRef,
+        "relativeRef === absoluteRef": relativeRef === absoluteRef,
+        "relativeRef !== fourRef": relativeRef !== fourRef,
+        "Math.ref === relativeRef": Math.ref === relativeRef,
+      },
+      add: {
+        x: 10,
+        y: 20,
+        sum: add(10, 20),
+      },
+      minus: {
+        x: 20,
+        y: 10,
+        difference: minus(20, 10),
+        subtract: subtract(20, 10),
+        "minus === subtract": minus === subtract,
+      },
+    }),
+    {
+      headers: { "content-type": "text/plain" },
+    },
+  );
+}
+
+if (import.meta.main) {
+  Deno.serve(
+    { port: 8080 },
+    serve,
+  );
+}

--- a/hub/@gates/five/math.ts
+++ b/hub/@gates/five/math.ts
@@ -1,0 +1,5 @@
+export * from "./add.ts";
+export * from "./minus.ts";
+
+export * as Add from "./add.ts";
+export * as Minus from "./minus.ts";

--- a/hub/@gates/five/minus.ts
+++ b/hub/@gates/five/minus.ts
@@ -1,0 +1,5 @@
+export function minus(a: number, b: number) {
+  return a - b;
+}
+
+export { minus as subtract };

--- a/hub/@gates/five/path/to/ref.ts
+++ b/hub/@gates/five/path/to/ref.ts
@@ -1,0 +1,1 @@
+export * as ref from "../../test.ts";

--- a/hub/@gates/five/test.ts
+++ b/hub/@gates/five/test.ts
@@ -1,0 +1,13 @@
+export const x = 1;
+
+export const {
+  y,
+  z: { z1, z2: z3 },
+  a: [a1, a2],
+} = {
+  y: "y",
+  z: { z1: "z1", z2: "z2-3" },
+  a: ["a1", "a2"],
+};
+
+export * from "npm:zod";

--- a/hub/@reframe/core/readme.md
+++ b/hub/@reframe/core/readme.md
@@ -1,12 +1,16 @@
-In this step, we pass @gates/four, which is same as @gates/three, but for this
-gate, we need to be able to cache read computations - like transpilation or
-fetching from npm - so that we don't repeat any computation.
+In this step, we pass @gates/five, which allows us to import other hooks, in
+this case, from @gates/three, @gates/four and even @reframe/core itself.
 
-For this, we create two new fs, cacheFs and memoryFs.
+Additionally, we will also support the ability to import from own hook by
+absolute path, instead of only relative path.
 
-- cacheFs(storage, source)
-  - takes two fs, storage and source, and caches each read from source to
-    storage.
-- memoryFs
-  - a simple in-memory fs to use as the storage for cacheFs, although note that
-    any compatible fs can be used as storage since FSes are composable.
+This is a big step, as it allows hooks to compose on each other, and also allows
+us to start building a library of hooks that we can import from.
+
+```ts
+// this will import from another hook
+import hook from "@org/hook/path/to/module.ts";
+
+// this will import from own hook
+import hook from "@/path/to/module.ts";
+```

--- a/hub/@reframe/core/server.ts
+++ b/hub/@reframe/core/server.ts
@@ -14,11 +14,15 @@ export default function serve(
   _version: string,
   entry: string,
 ) {
+  const hooksFs = localFs(`/`);
   const codeFs = localFs(`/@${org}/${name}`);
 
   const sourceFs: FS<Base> = cacheFs(
     routerFs()
-      .mount("/", () => codeFs)
+      // all hooks
+      .mount("/", () => hooksFs)
+      // our app
+      .mount("/@", () => codeFs)
       .mount("/~@", () => unmoduleFs(sourceFs))
       .mount("/~npm", () => npmFs()),
     memoryFs({}),


### PR DESCRIPTION
In this step, we pass `@gates/five`, which allows us to import other hooks, in
this case, from `@gates/three`, `@gates/four` and even `@reframe/core` itself.

Additionally, we will also support the ability to import from own hook by
absolute path, instead of only relative path.

This is a big step, as it allows hooks to compose on each other, and also allows
us to start building a library of hooks that we can import from.

```ts
// this will import from another hook
import hook from "@org/hook/path/to/module.ts";

// this will import from own hook
import hook from "@/path/to/module.ts";
```
