### PR TITLE
gate zero - serve js

### DIFF
--- a/hub/@gates/zero/main.js
+++ b/hub/@gates/zero/main.js
@@ -1,0 +1,5 @@
+export default function (request) {
+  return new Response(`Hello from ${request.url}!`, {
+    headers: { "content-type": "text/plain" },
+  });
+}

--- a/hub/@gates/zero/readme.md
+++ b/hub/@gates/zero/readme.md
@@ -1,0 +1,14 @@
+```sh
+$ cd hub
+$ ./@reframe/core/main.ts dev serve @gates/zero/main.js
+```
+
+As the first step, we create two hooks with following structure:
+
+- @reframe/core
+  - server.ts -- a server that can serve an entry
+  - main.ts -- a cli that accepts a path in the format
+    @org/name/path/to/entry.ts and can run the server
+
+- @gates/zero
+  - main.js, a js file that exports a server and does not have any imports

--- a/hub/@reframe/core/body.ts
+++ b/hub/@reframe/core/body.ts
@@ -1,0 +1,72 @@
+export type Body<
+  H extends Record<string, string> = Record<string, string>,
+  T = unknown,
+> = {
+  headers: H;
+  header<K extends keyof H>(key: K): H[K];
+  response(): Response;
+  text(): Promise<string>;
+  json(): Promise<T>;
+};
+
+export const text = <
+  H extends Record<string, string> = Record<string, string>,
+  T = unknown,
+>(
+  content: string,
+  headers: H,
+): Body<H, T> => {
+  return {
+    headers,
+    header: (key) => headers[key],
+    response: () =>
+      new Response(content, {
+        headers: {
+          "content-type": "text/plain",
+          ...headers,
+        },
+      }),
+    text: async () => content,
+    json: async () => JSON.parse(content),
+  };
+};
+
+export const json = <
+  T = unknown,
+  H extends Record<string, string> = Record<string, string>,
+>(
+  content: T,
+  headers: H,
+): Body<H, T> => {
+  return {
+    headers,
+    header: (key) => headers[key],
+    response: () =>
+      new Response(JSON.stringify(content), {
+        headers: {
+          "content-type": "application/json",
+          ...headers,
+        },
+      }),
+    text: async () => JSON.stringify(content),
+    json: async () => content,
+  };
+};
+
+export const response = <
+  H extends Record<string, string> = Record<string, string>,
+  T = unknown,
+>(
+  body: BodyInit | null,
+  headers: H,
+): Body<H, T> => {
+  const response = new Response(body, { headers });
+
+  return {
+    headers,
+    header: (key) => headers[key],
+    response: () => response,
+    text: async () => response.text(),
+    json: async () => response.json(),
+  };
+};

--- a/hub/@reframe/core/ctx/base.ts
+++ b/hub/@reframe/core/ctx/base.ts
@@ -1,0 +1,102 @@
+import { json, response, text } from "../body.ts";
+import { FSError } from "../fs/fs.ts";
+import { cleanPath, splitPath } from "../utils/path.ts";
+import type { Body } from "../body.ts";
+
+export type Base = {
+  request: Request;
+  operation: "read" | "write";
+
+  path: string;
+  segments: string[];
+
+  body: Body | null;
+
+  text: typeof text;
+  json: typeof json;
+  response: typeof response;
+
+  badRequest: (message: string) => FSError;
+  notFound: (message: string) => FSError;
+  notImplemented: (message: string) => FSError;
+  notAllowed: (message: string) => FSError;
+};
+
+export type Ctx<B extends Base> = B & {
+  create: (request: Request) => Ctx<B>;
+  cd: (path: string | ((_: string) => string)) => Ctx<B>;
+};
+
+export type BaseCtx = Ctx<Base>;
+
+const extendCreator = <B extends Base>(
+  create: (request: Request) => B,
+) => {
+  const extended: (request: Request) => Ctx<B> = (request) => {
+    const base = create(request);
+    return {
+      ...base,
+      create: extended,
+      cd: (path: string | ((_: string) => string)) => {
+        const newPath = cleanPath(
+          typeof path === "function" ? path(base.path) : path,
+        );
+
+        return extended(
+          new Request(new URL(newPath, request.url).toString(), request),
+        );
+      },
+    };
+  };
+
+  return extended;
+};
+
+export const createBaseCtx = extendCreator<Base>((
+  request: Request,
+) => {
+  const url = new URL(request.url);
+
+  const segments = splitPath(url.pathname);
+  const path = cleanPath(url.pathname) + url.search;
+
+  const operation = ["GET", "HEAD"].includes(request.method) ? "read" : "write";
+
+  return {
+    request,
+    operation,
+
+    path,
+    segments,
+
+    body: request.body &&
+      response(request.body, Object.fromEntries(request.headers)),
+
+    text,
+    json,
+    response,
+
+    notFound: (message) =>
+      FSError.notFound(
+        message ??
+          `resource not found: ${path}`,
+      ),
+
+    notImplemented: (message) =>
+      FSError.notImplemented(
+        message ?? `${operation.toUpperCase()} ${path} not implemented`,
+      ),
+
+    badRequest: (message) =>
+      FSError.badRequest(
+        message ??
+          `bad request: ${operation.toUpperCase()} ${path}`,
+      ),
+
+    notAllowed: (message) =>
+      FSError.notAllowed(
+        message ??
+          `not allowed: ${operation.toUpperCase()} ${path}`,
+      ),
+  };
+});

--- a/hub/@reframe/core/fs/fs.ts
+++ b/hub/@reframe/core/fs/fs.ts
@@ -1,0 +1,90 @@
+import { Base, Ctx } from "../ctx/base.ts";
+import { Body } from "../body.ts";
+
+export class FSError extends Error {
+  response: Response;
+
+  constructor(message: string, opts: ResponseInit) {
+    super(message);
+
+    this.response = new Response(message, opts);
+  }
+
+  static notFound(message: string) {
+    return new FSError(message, { status: 404 });
+  }
+
+  static notImplemented(message: string) {
+    return new FSError(message, { status: 501 });
+  }
+
+  static badRequest(message: string) {
+    return new FSError(message, { status: 400 });
+  }
+
+  static notAllowed(message: string) {
+    return new FSError(message, { status: 405 });
+  }
+
+  static is(err: unknown): err is FSError {
+    return err instanceof FSError;
+  }
+}
+
+export type FS<B extends Base> = {
+  name: string;
+  read: (
+    ctx: Ctx<B>,
+  ) => Promise<Body> & Pick<Body, "text" | "json"> & {
+    response: () => Promise<Response>;
+    header: (key: string) => Promise<string>;
+    headers: Promise<Record<string, string>>;
+  };
+  write: (
+    ctx: Ctx<B>,
+  ) => Promise<Body> & Pick<Body, "text" | "json"> & {
+    response: () => Promise<Response>;
+    header: (key: string) => Promise<string>;
+    headers: Promise<Record<string, string>>;
+  };
+  use: (_: (request: Request) => Ctx<B>) => {
+    fetch: (request: Request) => Promise<Response>;
+  };
+};
+
+export const createFs = <B extends Base>(name: string) => ({
+  read: (read: (ctx: Ctx<B>) => Promise<Body>) => ({
+    write: (write: (ctx: Ctx<B>) => Promise<Body>): FS<B> => ({
+      name,
+      read: (ctx) => {
+        const body = read(ctx);
+        return Object.assign(body, {
+          response: () => body.then((b) => b.response()),
+          text: () => body.then((b) => b.text()),
+          json: () => body.then((b) => b.json()),
+          header: <K extends string>(key: string) =>
+            body.then((b) => b.header(key)),
+          headers: body.then((b) => b.headers),
+        });
+      },
+      write: (ctx) => {
+        const body = write(ctx);
+        return Object.assign(body, {
+          response: () => body.then((b) => b.response()),
+          text: () => body.then((b) => b.text()),
+          json: () => body.then((b) => b.json()),
+          header: (key: string) => body.then((b) => b.header(key)),
+          headers: body.then((b) => b.headers),
+        });
+      },
+
+      use: (createCtx: (request: Request) => Ctx<B>) => ({
+        fetch: (request: Request) => {
+          const ctx = createCtx(request);
+          const body = ctx.operation === "read" ? read(ctx) : write(ctx);
+          return body.then((b) => b.response());
+        },
+      }),
+    }),
+  }),
+});

--- a/hub/@reframe/core/fs/local.ts
+++ b/hub/@reframe/core/fs/local.ts
@@ -1,0 +1,44 @@
+import { BaseCtx } from "../ctx/base.ts";
+import { getContentType } from "../utils/content-type.ts";
+import { cleanPath } from "../utils/path.ts";
+import { createFs } from "./fs.ts";
+import { ensureDir } from "https://deno.land/std@0.188.0/fs/ensure_dir.ts";
+import { dirname } from "https://deno.land/std@0.188.0/path/mod.ts";
+
+export const localFs = <Ctx extends BaseCtx>(prefix: `/${string}`) => {
+  return createFs<Ctx>("local")
+    .read(async (ctx) => {
+      const content = Deno.readTextFileSync(
+        Deno.cwd() + cleanPath(prefix + ctx.path),
+      );
+
+      return ctx.text(content, {
+        "x-fs-local-cwd": Deno.cwd(),
+        "x-fs-abs-path": Deno.cwd() + cleanPath(prefix + ctx.path),
+        "x-fs-local-stat-size": String(content.length),
+        "content-type": getContentType(ctx.path),
+      });
+    })
+    .write(async (ctx) => {
+      const path = Deno.cwd() + cleanPath(prefix + ctx.path);
+
+      await ensureDir(dirname(path));
+
+      if (!ctx.body) {
+        throw ctx.badRequest("missing body");
+      }
+
+      const content = await ctx.body.text();
+      Deno.writeFileSync(path, new TextEncoder().encode(content));
+
+      return ctx.text(
+        content,
+        {
+          "x-fs-local-cwd": Deno.cwd(),
+          "x-fs-abs-path": Deno.cwd() + cleanPath(prefix + ctx.path),
+          "x-fs-local-stat-size": String(content.length),
+          "content-type": getContentType(ctx.path),
+        },
+      );
+    });
+};

--- a/hub/@reframe/core/fs/module-server.ts
+++ b/hub/@reframe/core/fs/module-server.ts
@@ -1,0 +1,37 @@
+import { Base, Ctx } from "../ctx/base.ts";
+import { createFs, FS } from "./fs.ts";
+
+export const moduleServerFs = <CtxBase extends Base>(
+  base: FS<CtxBase>,
+  entry: string,
+): FS<CtxBase> => {
+  const serve = async (ctx: Ctx<CtxBase>) => {
+    const content = await base.read(ctx.cd(entry)).text();
+
+    const importUrl = URL.createObjectURL(
+      new Blob([content], { type: "text/javascript" }),
+    );
+
+    const module = await import(importUrl) as {
+      default: (request: Request) => Promise<Response>;
+    };
+
+    URL.revokeObjectURL(importUrl);
+
+    const result = await module.default(ctx.request);
+
+    if (result instanceof Response) {
+      return ctx.response(result.body, Object.fromEntries(result.headers));
+    }
+
+    throw ctx.badRequest("expected a response, got: " + JSON.stringify(result));
+  };
+
+  return createFs<CtxBase>("server")
+    .read(async (ctx) => {
+      return await serve(ctx);
+    })
+    .write(async (ctx) => {
+      return await serve(ctx);
+    });
+};

--- a/hub/@reframe/core/main.ts
+++ b/hub/@reframe/core/main.ts
@@ -1,0 +1,109 @@
+#!/usr/bin/env -S deno run --allow-read --allow-write --allow-net --allow-run --unstable-kv --watch
+
+import { parse } from "https://deno.land/std@0.200.0/flags/mod.ts";
+import serve from "./server.ts";
+
+// dev serve [entry]
+// prod serve [entry]
+// deploy [entry]
+// check [entry]
+
+type Command<
+  P extends Record<string, string | number | boolean>,
+  A extends string[],
+> = (
+  params: P,
+  ...args: A
+) => void | Promise<void>;
+
+type Commands = Command<{}, string[]> | {
+  [key: string]: Commands;
+};
+
+const parseEntryPath = (entry: string) => {
+  // @org/name(:version)?/path/to/entry
+
+  const [
+    ,
+    org,
+    name,
+    ,
+    version,
+    ,
+    path,
+  ] = /^@([^/]+)\/([^:/]+)(:([^/]+))?(\/(.+))?$/.exec(entry) || [];
+
+  if (!org || !name) {
+    console.error(`invalid entry path: ${entry}`);
+    Deno.exit(1);
+  }
+
+  return {
+    org,
+    name,
+    version,
+    path: path ?? "",
+  };
+};
+
+const commands = {
+  dev: {
+    serve: (_: {}, entry: string) => {
+      const { org, name, version, path } = parseEntryPath(entry);
+      serve(org, name, version, path);
+    },
+  },
+
+  prod: {
+    serve: (_: {}, entry: string) => {
+    },
+  },
+
+  deploy: (_: {}, entry: string) => {
+    console.log("deploy", entry);
+  },
+
+  check: (_: {}, entry: string) => {
+    const { org, name } = parseEntryPath(entry);
+    const command = new Deno.Command("/usr/bin/env", {
+      args: [
+        "-S",
+        "deno",
+        "check",
+        `@${org}/${name}/**/*.ts`,
+        `@${org}/${name}/**/*.tsx`,
+      ],
+    });
+
+    const { code, stdout, stderr } = command.outputSync();
+    if (code !== 0) {
+      console.error(new TextDecoder().decode(stderr));
+    }
+    console.log(new TextDecoder().decode(stdout));
+  },
+} satisfies Commands;
+
+if (import.meta.main) {
+  const args = parse(Deno.args);
+
+  let command: Commands = commands;
+
+  while (typeof command !== "function" && args._.length > 0) {
+    const next = String(args._.shift());
+
+    command = command[next];
+
+    if (!command) {
+      console.error(`unknown command ${next}`);
+      Deno.exit(1);
+    }
+  }
+
+  if (typeof command !== "function") {
+    console.error(`available commands: ${Object.keys(command).join(", ")}`);
+
+    Deno.exit(0);
+  }
+
+  await command(args, ...args._.map(String));
+}

--- a/hub/@reframe/core/readme.md
+++ b/hub/@reframe/core/readme.md
@@ -1,0 +1,9 @@
+As the first step, we will create two hooks with following structure:
+
+- `@reframe/core`
+  - `server.ts` -- a server that can serve an entry
+  - `main.ts` -- a cli that accepts a path in the format
+    @org/name/path/to/entry.ts and can run the server
+
+- `@gates/zero`
+  - `main.js`, a js file that exports a server and does not have any imports

--- a/hub/@reframe/core/server.ts
+++ b/hub/@reframe/core/server.ts
@@ -1,0 +1,28 @@
+import { createBaseCtx } from "./ctx/base.ts";
+import { localFs } from "./fs/local.ts";
+import { moduleServerFs } from "./fs/module-server.ts";
+
+export default function serve(
+  org: string,
+  name: string,
+  _version: string,
+  entry: string,
+) {
+  const sourceFs = localFs(`/@${org}/${name}`);
+
+  const appFs = moduleServerFs(
+    sourceFs,
+    entry,
+  );
+
+  Deno.serve(
+    { port: 8080 },
+    (request) => {
+      // ignore favicon
+      if (request.url.endsWith("/favicon.ico")) {
+        return new Response(null, { status: 404 });
+      }
+      return appFs.use(createBaseCtx).fetch(request);
+    },
+  );
+}

--- a/hub/@reframe/core/utils/content-type.ts
+++ b/hub/@reframe/core/utils/content-type.ts
@@ -1,0 +1,97 @@
+const mimeTypes: Record<string, string[]> = {
+  // application
+  "application/javascript": ["js", "mjs", "ts", "mts", "tsx", "jsx"],
+  // "application/typescript": ["ts", "mts"],
+  "application/wasm": ["wasm"],
+  "application/json": ["json", "map"],
+  "application/jsonc": ["jsonc"],
+  "application/json5": ["json5"],
+  "application/pdf": ["pdf"],
+  "application/xml": ["xml", "plist", "tmLanguage", "tmTheme"],
+  "application/zip": ["zip"],
+  "application/gzip": ["gz"],
+  "application/tar": ["tar"],
+  "application/tar+gzip": ["tar.gz", "tgz"],
+
+  // text
+  "text/html": ["html", "htm"],
+  "text/markdown": ["md", "markdown"],
+  "text/mdx": ["mdx"],
+  "text/css": ["css"],
+  "text/csv": ["csv"],
+  "text/yaml": ["yaml", "yml"],
+  "text/plain": ["txt", "glsl"],
+
+  // font
+  "font/ttf": ["ttf"],
+  "font/otf": ["otf"],
+  "font/woff": ["woff"],
+  "font/woff2": ["woff2"],
+  "font/collection": ["ttc"],
+
+  // image
+  "image/jpeg": ["jpg", "jpeg"],
+  "image/png": ["png"],
+  "image/apng": ["apng"],
+  "image/gif": ["gif"],
+  "image/webp": ["webp"],
+  "image/avif": ["avif"],
+  "image/svg+xml": ["svg", "svgz"],
+  "image/x-icon": ["ico"],
+
+  // audio
+  "audio/mp4": ["m4a"],
+  "audio/mpeg": ["mp3", "m3a"],
+  "audio/ogg": ["ogg", "oga"],
+  "audio/wav": ["wav"],
+  "audio/webm": ["weba"],
+
+  // video
+  "video/mp4": ["mp4", "m4v"],
+  "video/ogg": ["ogv"],
+  "video/webm": ["webm"],
+  "video/x-matroska": ["mkv"],
+
+  // shader
+  "x-shader/x-fragment": ["frag"],
+  "x-shader/x-vertex": ["vert"],
+};
+
+const typesMap = Object.entries(mimeTypes).reduce(
+  (map, [contentType, exts]) => {
+    exts.forEach((ext) => map.set(ext, contentType));
+    return map;
+  },
+  new Map<string, string>(),
+);
+
+export function trimSuffix(s: string, suffix: string): string {
+  if (suffix !== "" && s.endsWith(suffix)) {
+    return s.slice(0, -suffix.length);
+  }
+  return s;
+}
+
+export function registerType(ext: string, contentType: string) {
+  typesMap.set(ext, contentType);
+}
+
+function splitBy(
+  s: string,
+  searchString: string,
+  fromLast = false,
+): [prefix: string, suffix: string] {
+  const i = fromLast ? s.lastIndexOf(searchString) : s.indexOf(searchString);
+  if (i >= 0) {
+    return [s.slice(0, i), s.slice(i + searchString.length)];
+  }
+  return [s, ""];
+}
+
+export function getContentType(filename: string): string {
+  let [prefix, ext] = splitBy(filename, ".", true);
+  if (ext === "gz" && prefix.endsWith(".tar")) {
+    ext = "tar.gz";
+  }
+  return typesMap.get(ext) ?? "application/octet-stream";
+}

--- a/hub/@reframe/core/utils/path.ts
+++ b/hub/@reframe/core/utils/path.ts
@@ -1,0 +1,17 @@
+export function splitPath(path: string): string[] {
+  return path
+    .split(/[\/\\]+/g)
+    .filter((p) => p !== "" && p !== ".")
+    .reduce((slice, p) => {
+      if (p === "..") {
+        slice.pop();
+      } else {
+        slice.push(p);
+      }
+      return slice;
+    }, [] as Array<string>);
+}
+
+export function cleanPath(path: string): string {
+  return "/" + splitPath(path).join("/");
+}


### PR DESCRIPTION
```sh
$ cd hub
$ ./@reframe/core/main.ts dev serve @gates/zero/main.js
```

As the first step, we create two hooks with following structure:

- @reframe/core
  - server.ts -- a server that can serve an entry
  - main.ts -- a cli that accepts a path in the format
    @org/name/path/to/entry.ts and can run the server

- @gates/zero
  - main.js, a js file that exports a server and does not have any imports