### PR TITLE
gate three - import from npm

### DIFF
--- a/hub/@gates/three/add.ts
+++ b/hub/@gates/three/add.ts
@@ -1,0 +1,3 @@
+export { ref } from "./ref.ts";
+
+export const add = (a: number, b: number) => a + b;

--- a/hub/@gates/three/json.ts
+++ b/hub/@gates/three/json.ts
@@ -1,0 +1,4 @@
+export const parse = (json: string) => JSON.parse(json);
+export const stringify = (value: unknown) => JSON.stringify(value);
+
+export default { parse, stringify };

--- a/hub/@gates/three/main.ts
+++ b/hub/@gates/three/main.ts
@@ -1,0 +1,63 @@
+import { add, ref as ref1 } from "./add.ts";
+import { minus, subtract } from "./minus.ts";
+import { Type } from "npm:@sinclair/typebox";
+
+const T = Type.Object({
+  x: Type.Number(),
+  y: Type.Number(),
+  z: Type.Number(),
+});
+
+import * as Math from "./math.ts";
+import JSON from "./json.ts";
+
+import { ref } from "./ref.ts";
+
+export default function serve(request: Request) {
+  return new Response(
+    JSON.stringify({
+      text: `Hello from ${request.url}!`,
+      type: ref.object({
+        type: ref.literal("object"),
+        properties: ref.record(
+          ref.enum([
+            "x",
+            "y",
+            "z",
+          ]),
+          ref.object({
+            type: ref.literal("number").transform((x) => x.toUpperCase()),
+          }),
+        ),
+        required: ref.array(ref.string()),
+      }).parse(T),
+      ref: {
+        value: ref1,
+        "Math/ref === ref": Math.ref === ref,
+        "add/ref === ref": ref1 === ref,
+      },
+      add: {
+        x: 10,
+        y: 20,
+        sum: add(10, 20),
+      },
+      minus: {
+        x: 20,
+        y: 10,
+        difference: minus(20, 10),
+        subtract: subtract(20, 10),
+        "minus === subtract": minus === subtract,
+      },
+    }),
+    {
+      headers: { "content-type": "text/plain" },
+    },
+  );
+}
+
+if (import.meta.main) {
+  Deno.serve(
+    { port: 8080 },
+    serve,
+  );
+}

--- a/hub/@gates/three/math.ts
+++ b/hub/@gates/three/math.ts
@@ -1,0 +1,5 @@
+export * from "./add.ts";
+export * from "./minus.ts";
+
+export * as Add from "./add.ts";
+export * as Minus from "./minus.ts";

--- a/hub/@gates/three/minus.ts
+++ b/hub/@gates/three/minus.ts
@@ -1,0 +1,5 @@
+export function minus(a: number, b: number) {
+  return a - b;
+}
+
+export { minus as subtract };

--- a/hub/@gates/three/readme.md
+++ b/hub/@gates/three/readme.md
@@ -1,0 +1,48 @@
+```sh
+$ cd hub
+$ ./@reframe/core/main.ts dev serve @gates/three/~@/main.ts
+```
+
+In this step, we pass @gates/three, which contains imports from npm. For this,
+we create a new fs, npmFs, which resolves npm packages from esm.sh.
+
+Additionally, we update the Runtime.resolve function to be able to resolve
+import paths.
+
+An absolute path can have the following forms:
+
+- `/path/to/file`
+- `loader:/path/to/file`
+- `loader1:loader2:/path/to/file`
+- `/~loader/path/to/file (equivalent to loader:/path/to/file)`
+- `/~loader1/~loader2/path/to/file (equivalent to loader1:loader2:/path/to/file)`
+
+Path resolution works on resolving the loader part and the file part separately.
+Some examples:
+
+```js
+resolve("@/x/y/z/a.ts", "./b.ts"); // "@/x/y/z/b.ts"
+
+resolve("@/x/y/z/a.ts", "@reframe/core"); // "@reframe/core"
+
+resolve("@/x/y/z/a.ts", "@/x/y/z/d.ts"); // "@/x/y/z/d.ts"
+
+resolve("transpile:@/x/y/z/a.ts", "./b.ts"); // "transpile:@/x/y/z/b.ts"
+
+resolve("transpile:@/x/y/z/a.ts", "@reframe/core"); // "transpile:@reframe/core"
+
+resolve("transpile:@/x/y/z/a.ts", "@/x/y/z/d.ts"); // "transpile:@/x/y/z/d.ts"
+
+resolve("@/x/y/z/a.ts", "npm:react"); // "npm:react"
+
+resolve("npm:react", "/v135/react/index.js"); // "npm:v135/react/index.js"
+resolve("transpile:npm:react", "/v135/react/index.js"); // "transpile:npm:v135/react/index.js",
+
+resolve("transpile:@/x/y/z/a.ts", "/:./b.ts"); // "@/x/y/z/b.ts",
+
+resolve("transpile:npm:react", "/:transpile:/@reframe/core"); // "transpile:@reframe/core",
+
+resolve("transpile:npm:react", "/:/@reframe/core"); // "@reframe/core",
+
+resolve("transpile:npm:react", "..:/@reframe/core"); // "transpile:@reframe/core",
+```

--- a/hub/@gates/three/ref.ts
+++ b/hub/@gates/three/ref.ts
@@ -1,0 +1,1 @@
+export * as ref from "./test.ts";

--- a/hub/@gates/three/test.ts
+++ b/hub/@gates/three/test.ts
@@ -1,0 +1,13 @@
+export const x = 1;
+
+export const {
+  y,
+  z: { z1, z2: z3 },
+  a: [a1, a2],
+} = {
+  y: "y",
+  z: { z1: "z1", z2: "z2-3" },
+  a: ["a1", "a2"],
+};
+
+export * from "npm:zod";

--- a/hub/@reframe/core/fs/npm.ts
+++ b/hub/@reframe/core/fs/npm.ts
@@ -1,0 +1,30 @@
+import { Base } from "../ctx/ctx.ts";
+import { createFs } from "./lib/create.ts";
+
+export const npmFs = <C extends Base>(cdn = "https://esm.sh") =>
+  createFs<C>("npm")
+    .read(async (ctx) => {
+      const url = new URL(ctx.path, cdn);
+      url.searchParams.set("target", "esnext");
+      url.searchParams.set("external", "react,react-dom");
+
+      const response = await fetch(url);
+
+      if (!response.ok) {
+        console.error("ERROR", await response.text());
+        throw ctx.notFound(`module not found: ${ctx.path}`);
+      }
+
+      if (!response.body) {
+        throw ctx.notFound(`module does not have any body: ${ctx.path}`);
+      }
+
+      return ctx.response(
+        response.body,
+        Object.fromEntries(response.headers.entries()),
+      );
+    }).write(
+      (ctx) => {
+        throw ctx.notImplemented();
+      },
+    );

--- a/hub/@reframe/core/readme.md
+++ b/hub/@reframe/core/readme.md
@@ -1,20 +1,43 @@
-In this step, we pass @gates/two, which contains multiple typescript files that
-can import from each other. The most significant change here is to introduce
-runtime to ctx, which can import modules and evaluate them while maintaining
-referential integrity.
+In this step, we pass @gates/three, which contains imports from npm. For this,
+we create a new fs, npmFs, which resolves npm packages from esm.sh.
 
-### Runtime
+Additionally, we update the Runtime.resolve function to be able to resolve
+import paths.
 
-Runtime has three primary function, `resolve`, `import` and `importMany`.
+An absolute path can have the following forms:
 
-- `resolve` takes a path and returns the normalized path where app FS will give
-  us its content
-- `import` takes a path, fetches the content and evaluates it
-- `importMany` takes multiple paths, calls `import` on each of them and returns
-  the result as an object. Example:
+- /path/to/file
+- loader:/path/to/file
+- loader1:loader2:/path/to/file
+- /~loader/path/to/file (equivalent to loader:/path/to/file)
+- /~loader1/~loader2/path/to/file (equivalent to loader1:loader2:/path/to/file)
 
-```ts
-const imports = await Runtime.importMany("react", "./math.ts");
-const { useState } = imports["react"];
-const { add, subtract } = imports["./math.ts"];
+Path resolution works on resolving the loader part and the file part separately.
+Some examples:
+
+```js
+resolve("@/x/y/z/a.ts", "./b.ts"); // "@/x/y/z/b.ts"
+
+resolve("@/x/y/z/a.ts", "@reframe/core"); // "@reframe/core"
+
+resolve("@/x/y/z/a.ts", "@/x/y/z/d.ts"); // "@/x/y/z/d.ts"
+
+resolve("transpile:@/x/y/z/a.ts", "./b.ts"); // "transpile:@/x/y/z/b.ts"
+
+resolve("transpile:@/x/y/z/a.ts", "@reframe/core"); // "transpile:@reframe/core"
+
+resolve("transpile:@/x/y/z/a.ts", "@/x/y/z/d.ts"); // "transpile:@/x/y/z/d.ts"
+
+resolve("@/x/y/z/a.ts", "npm:react"); // "npm:react"
+
+resolve("npm:react", "/v135/react/index.js"); // "npm:v135/react/index.js"
+resolve("transpile:npm:react", "/v135/react/index.js"); // "transpile:npm:v135/react/index.js",
+
+resolve("transpile:@/x/y/z/a.ts", "/:./b.ts"); // "@/x/y/z/b.ts",
+
+resolve("transpile:npm:react", "/:transpile:/@reframe/core"); // "transpile:@reframe/core",
+
+resolve("transpile:npm:react", "/:/@reframe/core"); // "@reframe/core",
+
+resolve("transpile:npm:react", "..:/@reframe/core"); // "transpile:@reframe/core",
 ```

--- a/hub/@reframe/core/server.ts
+++ b/hub/@reframe/core/server.ts
@@ -1,12 +1,10 @@
-import { createBaseCtx } from "./ctx/ctx.ts";
+import { Base, FS } from "./ctx/ctx.ts";
+import { createBaseCtx } from "./ctx/base.ts";
 import { localFs } from "./fs/local.ts";
 import { moduleServerFs } from "./fs/module-server.ts";
+import { npmFs } from "./fs/npm.ts";
 import { routerFs } from "./fs/router.ts";
 import { unmoduleFs } from "./fs/unmodule.ts";
-
-const f = async () => {
-  throw 42;
-};
 
 export default function serve(
   org: string,
@@ -16,9 +14,10 @@ export default function serve(
 ) {
   const codeFs = localFs(`/@${org}/${name}`);
 
-  const sourceFs = routerFs()
+  const sourceFs: FS<Base> = routerFs()
     .mount("/", () => codeFs)
-    .mount("/@", () => unmoduleFs(codeFs));
+    .mount("/~@", () => unmoduleFs(sourceFs))
+    .mount("/~npm", () => npmFs());
 
   const appFs = routerFs()
     .mount("/", () =>

--- a/hub/@reframe/core/ts/transformers.ts
+++ b/hub/@reframe/core/ts/transformers.ts
@@ -128,8 +128,6 @@ export const unmodule = createVisitorTransformer<{
                 ),
               );
             });
-
-            // {symbol.exports}[<name>] = <property>;
           }
 
           if (!ts.isStringLiteral(statement.moduleSpecifier)) {
@@ -142,6 +140,8 @@ export const unmodule = createVisitorTransformer<{
             statement.moduleSpecifier.text,
             ctx.path,
           );
+
+          imports[specifier] ??= {};
 
           if (!statement.exportClause) {
             return ts.factory.createExpressionStatement(
@@ -164,8 +164,6 @@ export const unmodule = createVisitorTransformer<{
               ),
             );
           }
-
-          imports[specifier] ??= {};
 
           if (ts.isNamespaceExport(statement.exportClause)) {
             imports[specifier][statement.exportClause.name.text] = "*";

--- a/hub/@reframe/core/utils/path.ts
+++ b/hub/@reframe/core/utils/path.ts
@@ -15,3 +15,89 @@ export function splitPath(path: string): string[] {
 export function cleanPath(path: string): string {
   return "/" + splitPath(path).join("/");
 }
+
+export const splitSpecifier = (specifier: string): {
+  loaders: string[];
+  segments: string[];
+} => {
+  // TODO: (transpile:/path/to/loader):file
+  const parts = specifier.split(":");
+  const path = parts.pop()!;
+  const segments = path.split("/").filter(Boolean);
+  while (segments[0]?.startsWith("~")) {
+    parts.push(segments.shift()!.slice(1));
+  }
+  return {
+    loaders: parts,
+    segments,
+  };
+};
+
+export const joinSpecifier = (
+  loaders: string[],
+  segments: string[],
+): string => {
+  return (loaders.length === 0 ? "" : loaders.join(":") + ":") +
+    segments.join("/");
+};
+
+export const mergeSpecifiers = (a: string, b: string) => {
+  const mergeLoaders = (a: string[], b: string[]): string[] => {
+    if (b[0] === "/") {
+      return b.slice(1);
+    }
+
+    while (b[0] === "..") {
+      a.pop();
+      b.shift();
+    }
+
+    return [...a, ...b];
+  };
+
+  const mergeSegments = (a: string[], b: string[]): string[] => {
+    if (b[0] === "." || b[0] === "..") {
+      a.pop(); // remove the file name
+
+      for (const segment of b) {
+        if (segment === "..") {
+          if (a.length === 0) {
+            throw new Error(`Invalid specifier: ${b}`);
+          }
+
+          a.pop();
+        } else if (segment !== ".") {
+          a.push(segment);
+        }
+      }
+
+      return a;
+    }
+
+    return b;
+  };
+
+  const A = splitSpecifier(a);
+  const B = splitSpecifier(b);
+
+  return joinSpecifier(
+    mergeLoaders(A.loaders, B.loaders),
+    mergeSegments(A.segments, B.segments),
+  );
+};
+
+export const absolute = (specifier: string): string => {
+  if (specifier.startsWith(".") || specifier.startsWith("/")) {
+    throw new Error(`Expected a normalized specifier: ${specifier}`);
+  }
+
+  const parts = splitSpecifier(specifier);
+  return cleanPath(
+    "/" + parts.loaders.map((l) => "~" + l).join("/") + "/" +
+      parts.segments.join("/"),
+  );
+};
+
+export const resolve = (specifier: string, referrer: string): string => {
+  return absolute(mergeSpecifiers(referrer, specifier));
+};


### PR DESCRIPTION
```sh
$ cd hub
$ ./@reframe/core/main.ts dev serve @gates/three/~@/main.ts
```

In this step, we pass @gates/three, which contains imports from npm. For this,
we create a new fs, npmFs, which resolves npm packages from esm.sh.

Additionally, we update the Runtime.resolve function to be able to resolve
import paths.

An absolute path can have the following forms:

- `/path/to/file`
- `loader:/path/to/file`
- `loader1:loader2:/path/to/file`
- `/~loader/path/to/file (equivalent to loader:/path/to/file)`
- `/~loader1/~loader2/path/to/file (equivalent to loader1:loader2:/path/to/file)`

Path resolution works on resolving the loader part and the file part separately.
Some examples:

```js
resolve("@/x/y/z/a.ts", "./b.ts"); // "@/x/y/z/b.ts"

resolve("@/x/y/z/a.ts", "@reframe/core"); // "@reframe/core"

resolve("@/x/y/z/a.ts", "@/x/y/z/d.ts"); // "@/x/y/z/d.ts"

resolve("transpile:@/x/y/z/a.ts", "./b.ts"); // "transpile:@/x/y/z/b.ts"

resolve("transpile:@/x/y/z/a.ts", "@reframe/core"); // "transpile:@reframe/core"

resolve("transpile:@/x/y/z/a.ts", "@/x/y/z/d.ts"); // "transpile:@/x/y/z/d.ts"

resolve("@/x/y/z/a.ts", "npm:react"); // "npm:react"

resolve("npm:react", "/v135/react/index.js"); // "npm:v135/react/index.js"
resolve("transpile:npm:react", "/v135/react/index.js"); // "transpile:npm:v135/react/index.js",

resolve("transpile:@/x/y/z/a.ts", "/:./b.ts"); // "@/x/y/z/b.ts",

resolve("transpile:npm:react", "/:transpile:/@reframe/core"); // "transpile:@reframe/core",

resolve("transpile:npm:react", "/:/@reframe/core"); // "@reframe/core",

resolve("transpile:npm:react", "..:/@reframe/core"); // "transpile:@reframe/core",
```
