### PR TITLE
gate six - react server components

### DIFF
--- a/hub/@gates/six/app.tsx
+++ b/hub/@gates/six/app.tsx
@@ -1,0 +1,47 @@
+import React, { Suspense } from "npm:react@canary";
+import { type File, Files as Editor } from "./client.tsx";
+
+const getFiles = async (base: string, limit: number) => {
+  const paths: File[] = [];
+  const { walk } = await import("https://deno.land/std@0.170.0/fs/walk.ts");
+  for await (
+    const dirEntry of walk(base, {
+      skip: [/.git/],
+    })
+  ) {
+    if (dirEntry.isFile) {
+      paths.push({
+        path: dirEntry.path,
+        name: dirEntry.name,
+        content: await Deno.readTextFile(dirEntry.path),
+      });
+    }
+
+    if (paths.length >= limit) {
+      break;
+    }
+  }
+
+  return paths;
+};
+
+const Files = async () => {
+  const files = await getFiles("@reframe/core", 50);
+
+  return (
+    <>
+      <Suspense fallback={<div>Loading files...</div>}>
+        <Editor files={files} />
+      </Suspense>
+    </>
+  );
+};
+
+export default function App({ path }: { path: string }) {
+  return (
+    <Suspense fallback={<div>Loading!...</div>}>
+      <div>Hello {path}!!!!!</div>
+      <Files />
+    </Suspense>
+  );
+}

--- a/hub/@gates/six/client.tsx
+++ b/hub/@gates/six/client.tsx
@@ -1,0 +1,92 @@
+import React from "npm:react@canary";
+import { Button, install, Y } from "npm:@retune.so/sdk@latest/ui";
+import confetti from "npm:canvas-confetti@1.6.0";
+
+export type File = {
+  path: string;
+  name: string;
+  content: string;
+};
+
+if (typeof document !== "undefined") {
+  install(document.body);
+}
+
+export const Files = ({ files }: { files: File[] }) => {
+  const [selected, setSelected] = React.useState(files[0].path ?? "");
+
+  const selectedFile = files.find((file) => file.path === selected);
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "row",
+      }}
+    >
+      <div
+        style={{
+          flexDirection: "column",
+          display: "flex",
+          maxWidth: 240,
+        }}
+      >
+        <h1>Files (v45)</h1>
+
+        <Y>
+          <Button>Click me</Button>
+        </Y>
+
+        {files.map((file) => (
+          <div
+            onClick={() => setSelected(file.path)}
+            style={{
+              background: selected === file.path ? "lavender" : "white",
+              padding: 10,
+            }}
+          >
+            {file.path}
+          </div>
+        ))}
+      </div>
+
+      {selectedFile && (
+        <div
+          style={{
+            flexGrow: 1,
+            display: "flex",
+            flexDirection: "column",
+            gap: "20px",
+          }}
+        >
+          <button
+            onClick={() => {
+              confetti();
+              save(
+                selectedFile.path,
+                selectedFile.content,
+              );
+            }}
+          >
+            save!!!
+          </button>
+          <textarea
+            key={selectedFile.path}
+            defaultValue={selectedFile.content}
+            onChange={(event) => {
+              selectedFile.content = event.target.value;
+            }}
+            style={{
+              backgroundColor: "#f5f5f5",
+              fontFamily:
+                "ui-monospace,SFMono-Regular,SF Mono,Consolas,Liberation Mono,Menlo,monospace",
+              width: "100%",
+              height: "100%",
+              maxHeight: "min(800px, 90vh)",
+            }}
+          />
+        </div>
+      )}
+    </div>
+  );
+};

--- a/hub/@gates/six/main.tsx
+++ b/hub/@gates/six/main.tsx
@@ -1,0 +1,47 @@
+import React, { Suspense } from "npm:react@canary";
+import { render } from "@reframe/react/server.ts";
+
+import App from "./app.tsx";
+
+const Shell = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
+  return (
+    <html>
+      <head>
+        <meta charSet="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+      </head>
+      <body>
+        <Suspense>{children}</Suspense>
+      </body>
+    </html>
+  );
+};
+
+export default function serve(request: Request) {
+  const url = new URL(request.url);
+  const partial = url.pathname !== "/";
+  const element = !partial
+    ? (
+      <Shell>
+        <App path={url.pathname} />
+      </Shell>
+    )
+    : (
+      <div>
+        <App path={url.pathname} />
+      </div>
+    );
+
+  return render(element);
+}
+
+if (import.meta.main) {
+  Deno.serve(
+    { port: 8082 },
+    serve,
+  );
+}

--- a/hub/@gates/six/readme.md
+++ b/hub/@gates/six/readme.md
@@ -1,0 +1,26 @@
+```sh
+$ cd hub
+$ ./@reframe/core/main.ts dev serve @gates/six/~@/@/main.tsx
+```
+
+In this step, we pass `@gates/six`, where we can render react server components
+exported from hooks.
+
+To do that, we created a new library hook `@reframe/react` that exports a
+`render` function from `server.ts`, which converts a react element into a
+Response.
+
+```tsx
+import { render } from "@reframe/react/server.ts";
+
+export default function (request: Request) {
+  return render(<div>Hello, world!</div>);
+}
+```
+
+In addition, we created two new fs,
+
+- `httpFs`, reads remote urls
+- `debugFs`, evals a module and responds with the stringified result
+  - in future, we can expand this with `replFs`, which will allow us to interact
+    with a module in a repl-like environment with websockets

--- a/hub/@gates/six/test.ts
+++ b/hub/@gates/six/test.ts
@@ -1,0 +1,1 @@
+export const x = 42;

--- a/hub/@reframe/core/fs/debug.ts
+++ b/hub/@reframe/core/fs/debug.ts
@@ -1,0 +1,46 @@
+import { Base, FS } from "../ctx/ctx.ts";
+import { createFs } from "./lib/create.ts";
+
+const serialize = (value: unknown) => {
+  return JSON.stringify(value, (_, value) => {
+    if (typeof value === "function") {
+      return value.toString();
+    }
+
+    return value;
+  });
+};
+
+export const debugFs = <C extends Base>(
+  base: FS<C>,
+): FS<C> => {
+  return createFs<C>("debug")
+    .read(async (ctx) => {
+      const content = await ctx.forward(base).text();
+
+      const importUrl = URL.createObjectURL(
+        new Blob([content], { type: "text/javascript" }),
+      );
+
+      const moduleFn = await import(importUrl) as {
+        default: (_: unknown) => Promise<{
+          default: (request: Request) => Promise<Response>;
+        }>;
+      };
+
+      URL.revokeObjectURL(importUrl);
+
+      const module = await moduleFn.default(
+        ctx.switch(base).runtime(ctx.path),
+      );
+
+      console.log(">>> module", module);
+
+      return ctx.text(serialize(module), {
+        "content-type": "application/json",
+      });
+    })
+    .write((ctx) => {
+      throw ctx.notImplemented();
+    });
+};

--- a/hub/@reframe/core/fs/http.ts
+++ b/hub/@reframe/core/fs/http.ts
@@ -1,0 +1,28 @@
+import { Base } from "../ctx/ctx.ts";
+import { createFs } from "./lib/create.ts";
+
+export const httpFs = <C extends Base>(https = true) =>
+  createFs<C>("http")
+    .read(async (ctx) => {
+      const url = (https ? "https:/" : "http:/") + ctx.path;
+
+      const response = await fetch(url);
+
+      if (!response.ok) {
+        console.error("ERROR", await response.text());
+        throw ctx.notFound(`module not found: ${ctx.path}`);
+      }
+
+      if (!response.body) {
+        throw ctx.notFound(`module does not have any body: ${ctx.path}`);
+      }
+
+      return ctx.response(
+        response.body,
+        Object.fromEntries(response.headers.entries()),
+      );
+    }).write(
+      (ctx) => {
+        throw ctx.notImplemented();
+      },
+    );

--- a/hub/@reframe/core/fs/unmodule.ts
+++ b/hub/@reframe/core/fs/unmodule.ts
@@ -13,6 +13,7 @@ export const unmoduleFs = <C extends Base>(base: FS<C>) =>
       return ctx.text(transpiled, {
         ...response.headers,
         "x-fs-transpiler-imports": imports.join(","),
+        "content-type": "application/javascript",
       });
     }).write((ctx) => {
       throw ctx.notImplemented();

--- a/hub/@reframe/core/readme.md
+++ b/hub/@reframe/core/readme.md
@@ -1,16 +1,21 @@
-In this step, we pass @gates/five, which allows us to import other hooks, in
-this case, from @gates/three, @gates/four and even @reframe/core itself.
+In this step, we pass @gates/six, where we can render react server components
+exported from hooks.
 
-Additionally, we will also support the ability to import from own hook by
-absolute path, instead of only relative path.
+To do that, we created a new library hook `@reframe/react` that exports a
+`render` function from `server.ts`, which converts a react element into a
+Response.
 
-This is a big step, as it allows hooks to compose on each other, and also allows
-us to start building a library of hooks that we can import from.
+```tsx
+import { render } from "@reframe/react/server.ts";
 
-```ts
-// this will import from another hook
-import hook from "@org/hook/path/to/module.ts";
-
-// this will import from own hook
-import hook from "@/path/to/module.ts";
+export default function (request: Request) {
+  return render(<div>Hello, world!</div>);
+}
 ```
+
+In addition, we created two new fs,
+
+- `httpFs`, reads remote urls
+- `debugFs`, evals a module and responds with the stringified result
+  - in future, we can expand this with `replFs`, which will allow us to interact
+    with a module in a repl-like environment with websockets

--- a/hub/@reframe/core/server.ts
+++ b/hub/@reframe/core/server.ts
@@ -7,6 +7,8 @@ import { routerFs } from "./fs/router.ts";
 import { unmoduleFs } from "./fs/unmodule.ts";
 import { cacheFs } from "./fs/cache.ts";
 import { memoryFs } from "./fs/memory.ts";
+import { debugFs } from "./fs/debug.ts";
+import { httpFs } from "./fs/http.ts";
 
 export default function serve(
   org: string,
@@ -24,7 +26,9 @@ export default function serve(
       // our app
       .mount("/@", () => codeFs)
       .mount("/~@", () => unmoduleFs(sourceFs))
-      .mount("/~npm", () => npmFs()),
+      .mount("/~npm", () => npmFs())
+      .mount("/~http", () => httpFs(false))
+      .mount("/~https", () => httpFs()),
     memoryFs({}),
   );
 
@@ -34,7 +38,8 @@ export default function serve(
         sourceFs,
         entry,
       ))
-    .mount("/~", () => sourceFs);
+    .mount("/~", () => sourceFs)
+    .mount("/:", () => debugFs(unmoduleFs(sourceFs)));
 
   const server = appFs.use(createBaseCtx);
 

--- a/hub/@reframe/react/hook.tsx
+++ b/hub/@reframe/react/hook.tsx
@@ -1,0 +1,19 @@
+import React, { Suspense } from "npm:react@canary";
+const isBrowser = () =>
+  typeof window !== "undefined" && "location" in window &&
+  window.location !== undefined;
+
+export const Hook = async ({ src }: { src: string }) => {
+  if (isBrowser()) {
+    throw new Error("Hook can only be used on the server");
+  }
+
+  const response = await fetch(src);
+
+  return (
+    <slot
+      style={{ display: "contents" }}
+      dangerouslySetInnerHTML={{ __html: await response.text() }}
+    />
+  );
+};

--- a/hub/@reframe/react/server.ts
+++ b/hub/@reframe/react/server.ts
@@ -1,0 +1,43 @@
+import { type ReactElement } from "npm:react@canary";
+import { renderToReadableStream } from "npm:react-dom@canary/server";
+
+export const render = (element: ReactElement) =>
+  new Response(
+    new ReadableStream({
+      type: "bytes",
+      async start(controller) {
+        try {
+          const stream: ReadableStream = await renderToReadableStream(
+            element,
+            {
+              onError(error: Error) {
+                controller.enqueue(new TextEncoder().encode(`
+                  <script>
+                    console.error(${JSON.stringify(error.stack)});
+                  </script>
+                `));
+              },
+            },
+          );
+
+          const reader = stream.getReader();
+
+          while (true) {
+            const { done, value } = await reader.read();
+            if (done) {
+              break;
+            }
+            controller.enqueue(value);
+          }
+
+          controller.close();
+        } catch (error) {
+          console.log("[error]", error);
+          controller.error(error);
+        }
+      },
+    }, { highWaterMark: 0 }),
+    {
+      headers: { "content-type": "text/html" },
+    },
+  );


### PR DESCRIPTION
```sh
$ cd hub
$ ./@reframe/core/main.ts dev serve @gates/six/~@/@/main.tsx
```

In this step, we pass `@gates/six`, where we can render react server components
exported from hooks.

To do that, we created a new library hook `@reframe/react` that exports a
`render` function from `server.ts`, which converts a react element into a
Response.

```tsx
import { render } from "@reframe/react/server.ts";

export default function (request: Request) {
  return render(<div>Hello, world!</div>);
}
```

In addition, we created two new fs,

- `httpFs`, reads remote urls
- `debugFs`, evals a module and responds with the stringified result
  - in future, we can expand this with `replFs`, which will allow us to interact
    with a module in a repl-like environment with websockets
